### PR TITLE
Remove python from dh invocation's list of --with parameters.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -19,7 +19,7 @@ include /usr/share/dpkg/default.mk
 
 # main packaging script based on dh7 syntax
 %:
-	dh $@ --with autoreconf,python2,systemd
+	dh $@ --with autoreconf,systemd
 
 # dh_make generated override targets
 # This is example for Cmake (See https://bugs.debian.org/641051 )


### PR DESCRIPTION
At this time, we don't use debhelper's python support, as we aren't
generating debian python packages.